### PR TITLE
Fix/remove splash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -169,6 +169,7 @@ site
 back/user_guide
 
 whombat.db
+.ruff_cache/
 .pdm-python
 back/src/whombat/statics/*
 back/src/whombat/user_guide/*

--- a/back/src/whombat/system/app.py
+++ b/back/src/whombat/system/app.py
@@ -11,11 +11,7 @@ from fastapi.staticfiles import StaticFiles
 
 from whombat import exceptions
 from whombat.plugins import add_plugin_pages, add_plugin_routes, load_plugins
-from whombat.system.boot import (
-    close_splash_screen,
-    update_splash_screen,
-    whombat_init,
-)
+from whombat.system.boot import whombat_init
 from whombat.system.settings import Settings
 
 ROOT_DIR = Path(__file__).parent.parent
@@ -24,10 +20,7 @@ ROOT_DIR = Path(__file__).parent.parent
 @asynccontextmanager
 async def lifespan(settings: Settings, app: FastAPI):
     """Context manager to run startup and shutdown events."""
-    update_splash_screen("Initializing Whombat...")
     await whombat_init(settings, app)
-    update_splash_screen("Whombat is ready!")
-    close_splash_screen()
     yield
 
 

--- a/back/src/whombat/system/boot.py
+++ b/back/src/whombat/system/boot.py
@@ -75,24 +75,6 @@ def print_dev_message(settings: Settings):
     )
 
 
-def update_splash_screen(message: str) -> None:
-    try:
-        import pyi_splash  # type: ignore
-
-        pyi_splash.update_text(message)
-    except ImportError:
-        return
-
-
-def close_splash_screen() -> None:
-    try:
-        import pyi_splash  # type: ignore
-
-        pyi_splash.close()
-    except ImportError:
-        return
-
-
 async def whombat_init(settings: Settings, _: FastAPI):
     """Run at initialization."""
 

--- a/scripts/bundle_linux.sh
+++ b/scripts/bundle_linux.sh
@@ -41,7 +41,6 @@ build/.venv/bin/pyinstaller \
     --recursive-copy-metadata "numpy" \
 	--name whombat \
 	--onefile \
-    --splash "../assets/splash.png" \
 	app.py
 
 

--- a/scripts/bundle_windows.ps1
+++ b/scripts/bundle_windows.ps1
@@ -39,7 +39,6 @@ build\.venv\Scripts\pyinstaller `
     --name whombat `
     --onefile `
     --console `
-    --splash "..\assets\splash.png" `
     app.py
 
 


### PR DESCRIPTION
This PR removes the PyInstaller-generated splash screen from the application.

**Motivation**

The splash screen was causing several issues:

* **Crashes:** It led to application crashes on macOS.
* **Lack of Functionality:** We were unable to display meaningful information on the splash screen.
* **Visual Issues:** The splash screen image appeared with a distorted border, leading to a poor user experience.

Given these issues, we decided that removing the splash screen was the best course of action.

**Future Considerations**

While we have removed the PyInstaller-generated splash screen, we may explore creating a custom splash screen implementation in the future. This would allow us to have more control over the splash screen's appearance and functionality, potentially providing a better user experience.
