### PR TITLE
Fix Sound Event Geometry Update Bug

### DIFF
--- a/back/src/whombat/api/sound_events.py
+++ b/back/src/whombat/api/sound_events.py
@@ -327,6 +327,7 @@ class SoundEventAPI(
             The updated sound event.
         """
         geom_features = compute_geometric_features(sound_event.geometry)
+
         for feature in geom_features:
             try:
                 sound_event = await self.update_feature(
@@ -341,7 +342,9 @@ class SoundEventAPI(
                     schemas.Feature(name=feature.name, value=feature.value),
                 )
 
-        feature_mapping = {f.name: f for f in geom_features}
+        feature_mapping = {
+            f.name: schemas.Feature.model_validate(f) for f in geom_features
+        }
         sound_event = sound_event.model_copy(
             update=dict(
                 features=[


### PR DESCRIPTION
When annotating, updating a sound event's geometry caused it to visually revert to its original state. This was due to a type mismatch between 

soundevent.data.Feature (returned by the update function) and the expected whombat.schemas.Feature in the client's validation layer. The difference stems from the recent addition of terms to soundevent.

This PR resolves the issue by correctly casting  soundevent.data.Feature to whombat.schemas.Feature before sending the data back to the client. This ensures the validation passes and the updated geometry persists.