### PR TITLE
Upgrade macOS Runner Image to macos-13

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -25,7 +25,7 @@ jobs:
         os:
           - ubuntu-20.04
           - windows-latest
-          - macos-12
+          - macos-13
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
GitHub recently deprecated the macos-12 runner image, which was used to build the bundled Whombat executable for macOS.

To ensure maximum compatibility with macOS versions, we should use the oldest available runner image. Executables bundled on an older macOS version are generally forward-compatible with newer releases.

This PR updates the workflow to use the macos-13 runner image for building the macOS executable.