### PR TITLE
Fix/gh 48 export relative paths

### DIFF
--- a/back/src/whombat/api/datasets.py
+++ b/back/src/whombat/api/datasets.py
@@ -752,13 +752,19 @@ class DatasetAPI(
         self,
         session: AsyncSession,
         dataset: schemas.Dataset,
+        audio_dir: Path | None = None,
     ) -> AOEFObject:
+        if audio_dir is None:
+            audio_dir = get_settings().audio_dir
+
+        dataset_audio_dir = audio_dir / dataset.audio_dir
+
         soundevent_dataset = await self.to_soundevent(
             session,
             dataset,
-            audio_dir=dataset.audio_dir,
+            audio_dir=audio_dir,
         )
-        return to_aeof(soundevent_dataset, audio_dir=dataset.audio_dir)
+        return to_aeof(soundevent_dataset, audio_dir=dataset_audio_dir)
 
 
 datasets = DatasetAPI()

--- a/back/src/whombat/routes/datasets.py
+++ b/back/src/whombat/routes/datasets.py
@@ -136,10 +136,15 @@ async def delete_dataset(
 async def download_dataset_json(
     session: Session,
     dataset_uuid: UUID,
+    settings: WhombatSettings,
 ):
     """Export a dataset."""
     whombat_dataset = await api.datasets.get(session, dataset_uuid)
-    obj = await api.datasets.export_dataset(session, whombat_dataset)
+    obj = await api.datasets.export_dataset(
+        session,
+        whombat_dataset,
+        audio_dir=settings.audio_dir,
+    )
     filename = f"{whombat_dataset.name}_{obj.created_on.isoformat()}.json"
     return Response(
         obj.model_dump_json(),

--- a/back/tests/test_api/test_datasets.py
+++ b/back/tests/test_api/test_datasets.py
@@ -777,7 +777,7 @@ async def test_exported_datasets_paths_are_not_absolute(
         session,
         example_dataset,
         dataset_audio_dir=audio_dir,
-        audio_dir=audio_dir,
+        audio_dir=example_data_dir,
     )
     exported = await api.datasets.export_dataset(session, whombat_dataset)
 


### PR DESCRIPTION
This pull request addresses the issue reported by @namitha-sh (#48) where exported recording paths were not correctly relative to the dataset's audio directory.

While a previous attempt to address this (PR #49) introduced a test to verify relative paths, the test itself contained a flaw.  This PR corrects the test implementation and applies the necessary fix to the `export` method of the dataset API to ensure all exported recording paths are now correctly relative to the dataset's audio directory.