### PR TITLE
Fix/gh 53 unable to add tags

### DIFF
--- a/back/src/whombat/routes/tags.py
+++ b/back/src/whombat/routes/tags.py
@@ -139,7 +139,7 @@ async def create_tag(
     data: schemas.TagCreate,
 ):
     """Create a new tag."""
-    tag = await api.tags.create(session, key=data.key, value=data.value)
+    tag = await api.tags.get_or_create(session, key=data.key, value=data.value)
     await session.commit()
     return tag
 

--- a/back/tests/test_routers/test_tags.py
+++ b/back/tests/test_routers/test_tags.py
@@ -1,0 +1,31 @@
+"""Test suite for the Tags endpoints."""
+
+from fastapi.testclient import TestClient
+
+from whombat import schemas
+
+
+async def test_create_tag_returns_existing_tag_if_duplicate(
+    client: TestClient,
+    tag: schemas.Tag,
+    cookies: dict[str, str],
+):
+    response = client.post(
+        "/api/v1/tags/",
+        json={"key": tag.key, "value": tag.value},
+        cookies=cookies,
+    )
+
+    assert response.status_code == 200
+    content = response.json()
+
+    assert content["key"] == tag.key
+    assert content["value"] == tag.value
+
+    # And do it again for good measure
+    response = client.post(
+        "/api/v1/tags/",
+        json={"key": tag.key, "value": tag.value},
+        cookies=cookies,
+    )
+    assert response.status_code == 200

--- a/front/src/app/components/annotation/AnnotationTagPalette.tsx
+++ b/front/src/app/components/annotation/AnnotationTagPalette.tsx
@@ -36,6 +36,7 @@ export default function AnnotationTagPalette({
       tagColorFn={tagColorFn}
       onSelectTag={onAddTag}
       onRemoveTag={onRemoveTag}
+      onCreateTag={onAddTag}
       onClick={(tag) =>
         addClipAnnotationTag.mutate(tag, {
           onSuccess: () => toast.success("Tag added."),

--- a/front/src/app/components/tags/ProjectTagsSearch.tsx
+++ b/front/src/app/components/tags/ProjectTagsSearch.tsx
@@ -1,17 +1,17 @@
-import { ComponentProps, useContext, useMemo } from "react";
+import { ComponentProps, useCallback, useContext, useMemo } from "react";
 
 import useAnnotationProject from "@/app/hooks/api/useAnnotationProject";
 
 import AnnotationProjectContext from "@/app/contexts/annotationProject";
 
+import { type Tag } from "@/lib/types";
+
 import TagSearchBar from "./TagSearchBar";
 
-export default function ProjectTagSearch(
-  props: Omit<
-    ComponentProps<typeof TagSearchBar>,
-    "onCreateTag" | "filter" | "fixed"
-  >,
-) {
+export default function ProjectTagSearch({
+  onCreateTag,
+  ...props
+}: Omit<ComponentProps<typeof TagSearchBar>, "filter" | "fixed">) {
   const annotationProject = useContext(AnnotationProjectContext);
 
   const { data, addTag } = useAnnotationProject({
@@ -26,9 +26,17 @@ export default function ProjectTagSearch(
     [data, annotationProject],
   );
 
+  const handleCreateTag = useCallback(
+    (tag: Tag) => {
+      addTag.mutate(tag);
+      onCreateTag?.(tag);
+    },
+    [addTag, onCreateTag],
+  );
+
   return (
     <TagSearchBar
-      onCreateTag={(tag) => addTag.mutate(tag)}
+      onCreateTag={handleCreateTag}
       filter={filter}
       fixed={["annotation_project"]}
       {...props}


### PR DESCRIPTION
This PR addresses issue #53  where adding tags from the annotation view failed under certain conditions.

## Problem 1: New Tags Not Added to Project

Previously, when a user created a tag (e.g. via the tag palette or sound event tags), the tag was not automatically associated with the annotation project. As a result, it wouldn't appear in the tag search bar and couldn't be used.

**Fix:** Updated the logic for tag creation in the annotation view to ensure new tags are now properly added to the annotation project upon creation.

## Problem 2: Existing Tags Not Registered to Project

Existing tags that weren't yet associated with the project also caused issues:

- They wouldn't appear in the tag search bar.
- Attempts to create them failed, since the backend rejected duplicates.

**Fix:** Improved the /tags/ endpoint behavior on creation so that it now either:

- Creates a new tag, or
- Returns an existing one and associates it with the project if not already linked.

This allows users to "create" a tag from the annotation view, even if it already exists, and ensures it becomes available within the project context.

## Future Improvement:

We could improve the UX by:

- Showing existing-but-unregistered tags in the search dropdown.
- Automatically adding them to the project when selected.