### PR TITLE
Return correct content range and length from audio endpoint

### DIFF
--- a/back/src/whombat/routes/audio.py
+++ b/back/src/whombat/routes/audio.py
@@ -69,7 +69,7 @@ async def stream_recording_audio(
     )
 
     headers = {
-        "Content-Range": f"bytes {start}-{end}/{filesize}",
+        "Content-Range": f"bytes {start}-{end-1}/{filesize}",
         "Content-Length": f"{len(data)}",
         "Accept-Ranges": "bytes",
     }


### PR DESCRIPTION
This PR resolves an issue #51 where audio playback would abruptly stop before the end of the audio file in Chrome and Safari, while working as expected in Firefox.

**Root Cause**: The issue stemmed from how different browsers handle HTTP range requests. Chrome and Safari enforce stricter validation of Content-Range and Content-Length headers than Firefox.

Previously, the backend was returning headers in the form:

```
Content-Range: bytes a-b/total
Content-Length: (b - a)
```

However, per the [HTTP Range Requests specification](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/Range_requests), the byte range is inclusive (a-b includes both a and b). Therefore, the correct Content-Length should be:

```
Content-Length: (b - a + 1)
```

Firefox tolerated the off-by-one discrepancy, but Chrome and Safari did not, leading to incomplete audio playback when streaming.

**Fix**: Updated the backend to:

- Correctly calculate Content-Length as (b - a + 1)
- Ensure that Content-Range accurately reflects the byte range being served

Audio playback now functions correctly across Chrome and Firefox. Testing in Safari is pending.

A big thanks to @federico-ferlito for pointing out this issue!