### PR TITLE
Feat/Add cursor-tracking lines to spectrogram for precise measurements

### DIFF
--- a/front/src/app/components/spectrograms/ClipAnnotationCanvas.tsx
+++ b/front/src/app/components/spectrograms/ClipAnnotationCanvas.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { mergeProps } from "react-aria";
 
 import SoundEventSpectrogramTags from "@/app/components/sound_event_annotations/SoundEventSpectrogramTags";
@@ -17,6 +17,7 @@ import useSpectrogramImages from "@/lib/hooks/spectrogram/useSpectrogramImages";
 import useSpectrogramInteractions from "@/lib/hooks/spectrogram/useSpectrogramInteractions";
 import useElementSize from "@/lib/hooks/utils/useElementSize";
 
+import { drawCursor } from "@/lib/draw/cursor";
 import drawOnset from "@/lib/draw/onset";
 import type {
   AnnotationState,
@@ -25,6 +26,7 @@ import type {
   CanvasProps,
   ClipAnnotation,
   Geometry,
+  Position,
   Recording,
   SoundEventAnnotation,
   SpectrogramSettings,
@@ -65,6 +67,11 @@ export default function ClipAnnotationCanvas({
   enabled?: boolean;
 }) {
   const { size: dimensions, ref } = useElementSize<HTMLCanvasElement>();
+
+  const [cursorPosition, setCursorPosition] = useState<Position>({
+    time: 0,
+    freq: 0,
+  });
 
   const {
     data = clipAnnotation,
@@ -213,6 +220,7 @@ export default function ClipAnnotationCanvas({
       drawSelect(ctx);
       drawDelete(ctx);
       drawEdit(ctx);
+      drawCursor(ctx, cursorPosition, viewport);
     },
     [
       audio.currentTime,
@@ -223,6 +231,7 @@ export default function ClipAnnotationCanvas({
       drawSelect,
       drawEdit,
       drawDelete,
+      cursorPosition,
     ],
   );
 
@@ -246,6 +255,7 @@ export default function ClipAnnotationCanvas({
         height={height}
         drawFn={drawFn}
         canvasRef={ref}
+        onHover={({ position }) => setCursorPosition(position)}
         {...canvasProps}
       />
     </SpectrogramTags>

--- a/front/src/app/components/spectrograms/RecordingCanvas.tsx
+++ b/front/src/app/components/spectrograms/RecordingCanvas.tsx
@@ -1,14 +1,16 @@
-import { useCallback } from "react";
+import { useCallback, useState } from "react";
 
 import CanvasBase from "@/lib/components/spectrograms/Canvas";
 
 import useSpectrogramImages from "@/lib/hooks/spectrogram/useSpectrogramImages";
 import useSpectrogramInteractions from "@/lib/hooks/spectrogram/useSpectrogramInteractions";
 
+import { drawCursor } from "@/lib/draw/cursor";
 import drawOnset from "@/lib/draw/onset";
 import type {
   AudioController,
   AudioSettings,
+  Position,
   Recording,
   SpectrogramSettings,
   SpectrogramState,
@@ -34,6 +36,11 @@ export default function RecordingCanvas({
   spectrogramSettings: SpectrogramSettings;
   height?: number;
 }) {
+  const [cursorPosition, setCursorPosition] = useState<Position>({
+    time: 0,
+    freq: 0,
+  });
+
   const { drawFn: drawSpectrogram } = useSpectrogramImages({
     recording,
     audioSettings,
@@ -59,8 +66,9 @@ export default function RecordingCanvas({
 
       drawOnset(ctx, time);
       drawInteractions(ctx, viewport);
+      drawCursor(ctx, cursorPosition, viewport);
     },
-    [audio.currentTime, drawSpectrogram, drawInteractions],
+    [audio.currentTime, drawSpectrogram, drawInteractions, cursorPosition],
   );
 
   return (
@@ -68,6 +76,7 @@ export default function RecordingCanvas({
       viewport={viewport.viewport}
       height={height}
       drawFn={drawFn}
+      onHover={({ position }) => setCursorPosition(position)}
       {...props}
     />
   );

--- a/front/src/lib/draw/cursor.ts
+++ b/front/src/lib/draw/cursor.ts
@@ -1,0 +1,44 @@
+import { setBorderStyle, setFontStyle } from "@/lib/draw/styles";
+import type { Position, SpectrogramWindow } from "@/lib/types";
+import { scaleFreqToViewport, scaleTimeToViewport } from "@/lib/utils/geometry";
+
+export function drawCursor(
+  ctx: CanvasRenderingContext2D,
+  position: Position,
+  viewport: SpectrogramWindow,
+  {
+    buffer = 5,
+  }: {
+    buffer?: number;
+  } = {},
+) {
+  const y = scaleFreqToViewport(position.freq, viewport, ctx.canvas.height);
+  const x = scaleTimeToViewport(position.time, viewport, ctx.canvas.width);
+
+  setBorderStyle(ctx, {
+    borderColor: "black",
+    borderWidth: 1,
+    borderDash: [10, 5],
+  });
+
+  ctx.beginPath();
+  ctx.moveTo(0, y);
+  ctx.lineTo(ctx.canvas.width, y);
+  ctx.stroke();
+
+  ctx.beginPath();
+  ctx.moveTo(x, 0);
+  ctx.lineTo(x, ctx.canvas.height);
+  ctx.stroke();
+
+  setFontStyle(ctx, { fontColor: "black", textBaseline: "bottom", fontSize: 14 });
+  ctx.fillText(`${position.freq.toFixed(2)} Hz`, x + buffer, y - buffer);
+  const height = ctx.measureText(
+    `${position.freq.toFixed(2)} Hz`,
+  ).emHeightAscent;
+  ctx.fillText(
+    `${position.time.toFixed(5)} s`,
+    x + buffer,
+    y - buffer - height,
+  );
+}

--- a/front/src/lib/draw/cursor.ts
+++ b/front/src/lib/draw/cursor.ts
@@ -31,7 +31,11 @@ export function drawCursor(
   ctx.lineTo(x, ctx.canvas.height);
   ctx.stroke();
 
-  setFontStyle(ctx, { fontColor: "black", textBaseline: "bottom", fontSize: 14 });
+  setFontStyle(ctx, {
+    fontColor: "black",
+    textBaseline: "bottom",
+    fontSize: 14,
+  });
   ctx.fillText(`${position.freq.toFixed(2)} Hz`, x + buffer, y - buffer);
   const height = ctx.measureText(
     `${position.freq.toFixed(2)} Hz`,


### PR DESCRIPTION
This PR enhances the spectrogram by improving precision when measuring the time and frequency of sounds. Accurately identifying these values is essential for measuring, analyzing, and annotating sound events.

While the spectrogram already includes labeled time and frequency axes, they can be difficult to use for precise measurements. To improve this, I’ve added dynamic horizontal and vertical dashed lines that track the cursor’s position. These lines display real-time time and frequency values, making it easier to analyze sound characteristics with greater accuracy.

Future enhancements could include automated acoustic feature computation (e.g., peak frequency detection) and additional measurement tools.