### PR TITLE
Fix/GH 63 whombat on python 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,6 +14,7 @@ jobs:
       matrix:
         python-version:
           - "3.12"
+          - "3.11"
         os:
           - ubuntu-latest
           - windows-latest

--- a/back/pyproject.toml
+++ b/back/pyproject.toml
@@ -79,13 +79,15 @@ dev-dependencies = [
 venvPath = "."
 venv = ".venv"
 include = ["src"]
+pythonVersion = "3.11"
+pythonPlatform = "All"
 
 [tool.pydocstyle]
 convention = "numpy"
 
 [tool.ruff]
 line-length = 79
-target-version = "py312"
+target-version = "py311"
 
 [tool.ruff.format]
 docstring-code-format = true

--- a/back/src/whombat/api/common/utils.py
+++ b/back/src/whombat/api/common/utils.py
@@ -2,8 +2,7 @@
 
 import re
 from dataclasses import MISSING, fields
-from itertools import batched
-from typing import Any, Callable, Sequence, TypeVar
+from typing import Any, Callable, Generator, Iterable, Sequence, TypeVar
 
 from pydantic import BaseModel
 from sqlalchemy import Result, Select, func, insert, select
@@ -18,6 +17,25 @@ from sqlalchemy.sql.expression import ColumnElement
 from whombat import exceptions, models
 from whombat.core.common import remove_duplicates
 from whombat.filters.base import Filter
+
+try:
+    from itertools import batched  # type: ignore
+except ImportError:
+    from itertools import islice
+
+    A = TypeVar("A")
+
+    def batched(
+        iterable: Iterable[A], n: int, *, strict: bool = False
+    ) -> Generator[tuple[A, ...], None, None]:
+        if n < 1:
+            raise ValueError("n must be at least one")
+        iterator = iter(iterable)
+        while batch := tuple(islice(iterator, n)):
+            if strict and len(batch) != n:
+                raise ValueError("batched(): incomplete batch")
+            yield batch
+
 
 __all__ = [
     "add_feature_to_object",

--- a/back/uv.lock
+++ b/back/uv.lock
@@ -1,4 +1,5 @@
 version = 1
+revision = 1
 requires-python = ">=3.11"
 resolution-markers = [
     "python_full_version < '3.12'",
@@ -2482,7 +2483,7 @@ wheels = [
 
 [[package]]
 name = "whombat"
-version = "0.7.3"
+version = "0.8.2"
 source = { editable = "." }
 dependencies = [
     { name = "aiosqlite" },
@@ -2545,6 +2546,7 @@ requires-dist = [
     { name = "soundevent", extras = ["all"], specifier = ">=2.1.1" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.30.6" },
 ]
+provides-extras = ["postgre"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
This PR addresses #63 where Whombat fails to start in Python 3.11 due to an ImportError. The issue occurs because itertools.batched is only available in Python 3.12, but Whombat attempts to import it in Python 3.11.