### PR TITLE
Fix/Use relative paths in annotation project exports

### DIFF
--- a/back/src/whombat/api/annotation_projects.py
+++ b/back/src/whombat/api/annotation_projects.py
@@ -2,7 +2,7 @@
 
 import os
 from pathlib import Path
-from typing import List, Sequence
+from typing import Sequence
 from uuid import UUID
 
 from soundevent import data
@@ -20,7 +20,6 @@ from whombat.filters.annotation_tasks import (
 )
 from whombat.filters.base import Filter
 from whombat.filters.clip_annotations import AnnotationProjectFilter
-from whombat.models.dataset import DatasetRecording
 from whombat.system.settings import get_settings
 
 __all__ = [

--- a/back/src/whombat/routes/annotation_projects.py
+++ b/back/src/whombat/routes/annotation_projects.py
@@ -185,7 +185,10 @@ async def download_annotation_project(
     project = await api.annotation_projects.to_soundevent(
         session, whombat_project
     )
-    obj = to_aeof(project)
+    base_dir = await api.annotation_projects.get_base_dir(
+        session, whombat_project
+    )
+    obj = to_aeof(project, audio_dir=base_dir)
     filename = f"{project.name}_{obj.created_on.isoformat()}.json"
     return Response(
         obj.model_dump_json(),

--- a/back/tests/test_routers/test_annotation_projects.py
+++ b/back/tests/test_routers/test_annotation_projects.py
@@ -1,0 +1,44 @@
+"""Test the Annotation Project endpoints."""
+
+from fastapi.testclient import TestClient
+from soundevent.io import aoef
+
+from whombat import schemas
+
+
+def test_exported_annotation_projects_paths_are_relative(
+    client: TestClient,
+    annotation_project: schemas.AnnotationProject,
+    clip: schemas.Clip,
+    cookies: dict[str, str],
+):
+    # Create annotation task
+    response = client.post(
+        "/api/v1/annotation_tasks/",
+        params={
+            "annotation_project_uuid": str(annotation_project.uuid),
+        },
+        json=[str(clip.uuid)],
+        cookies=cookies,
+    )
+
+    assert response.status_code == 200
+
+    # Download
+    response = client.get(
+        "/api/v1/annotation_projects/detail/download/",
+        params={
+            "annotation_project_uuid": str(annotation_project.uuid),
+        },
+        cookies=cookies,
+    )
+
+    assert response.status_code == 200
+
+    content = aoef.AOEFObject.model_validate(response.json())
+
+    assert content.data.recordings
+    assert len(content.data.recordings) == 1
+
+    recording = content.data.recordings[0]
+    assert not recording.path.is_absolute()

--- a/back/tests/test_routers/test_annotation_projects.py
+++ b/back/tests/test_routers/test_annotation_projects.py
@@ -1,5 +1,7 @@
 """Test the Annotation Project endpoints."""
 
+from pathlib import Path
+
 from fastapi.testclient import TestClient
 from soundevent.io import aoef
 
@@ -9,6 +11,7 @@ from whombat import schemas
 def test_exported_annotation_projects_paths_are_relative(
     client: TestClient,
     annotation_project: schemas.AnnotationProject,
+    audio_dir: Path,
     clip: schemas.Clip,
     cookies: dict[str, str],
 ):
@@ -42,3 +45,4 @@ def test_exported_annotation_projects_paths_are_relative(
 
     recording = content.data.recordings[0]
     assert not recording.path.is_absolute()
+    assert (audio_dir / recording.path).exists()


### PR DESCRIPTION
This PR addresses an issue where annotation project exports included absolute paths to recordings instead of paths relative to a common base directory. Absolute paths are undesirable as they reduce portability and may leak personal folder structures.

### Root Cause  
The problem was traced to the `whombat.routes.annotation_project.download` function, which handles the export of annotation projects in AEOF format. Although the conversion function accepts an optional `audio_dir` parameter to compute relative paths, this argument was not being utilized.

### Solution  
Because recordings within a single annotation project may originate from different datasets—each with its own root directory—it wasn’t feasible to simply make paths relative to their individual dataset roots. Furthermore, the same recording might appear in multiple datasets with different root paths, complicating the decision further.

To resolve this, I implemented a new `annotation_project.get_base_dir` function, which computes the first common parent directory across all dataset root directories involved in the project. This common base directory is then used to generate relative paths for all recordings in the export.

This approach allows users to copy or share the annotation project folder (or any subsection of it) while maintaining a consistent internal structure. Importing such a project elsewhere should work without modification, improving portability and usability.

### Additional Changes  
- Updated the export logic to use the computed `base_dir`.
- Added unit tests for:
  - `get_base_dir` with multiple datasets.
  - The single-dataset case to confirm it returns that dataset's root directory.
  - Ensuring the exported annotation project uses paths relative to `base_dir`.