### PR TITLE
Ensure extra dependencies are included in docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /guide
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=back/uv.lock,target=uv.lock \
     --mount=type=bind,source=back/pyproject.toml,target=pyproject.toml \
-    uv sync --frozen --no-install-project --dev
+    uv sync --frozen --no-install-project --dev --all-extras
 
 COPY back/docs /guide/docs
 COPY back/mkdocs-guide.yml /guide/mkdocs-guide.yml


### PR DESCRIPTION
This PR fixes an issue where the built Docker image did not include the optional dependencies required for PostgreSQL database support (asyncpg, psycopg2-binary). 

The issue was caused by the first uv sync command in the first stage of Dockerfile not explicitly installing the optional dependencies. This has been corrected by ensuring --all-extras is passed at this stage and all others.