### PR TITLE
fix: Update ubuntu version in bundle workflow

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -23,7 +23,7 @@ jobs:
         python-version:
           - "3.12"
         os:
-          - ubuntu-20.04
+          - ubuntu-22.04
           - windows-latest
           - macos-13
 


### PR DESCRIPTION
The GitHub Actions runner ubuntu-20.04 used in the bundle workflow is deprecated. This PR updates it to ubuntu-22.04, the next non-deprecated version.

We explicitly use ubuntu-22.04 instead of ubuntu-latest since pinning to a specific version helps maintain compatibility with future Ubuntu releases, since artifacts built on a known version are generally forward-compatible.