### PR TITLE
feat: configurable default spectrogram viewing window

### DIFF
--- a/back/docs/.mdslw.toml
+++ b/back/docs/.mdslw.toml
@@ -1,0 +1,4 @@
+max-width = 0
+lang = "en"
+end-markers = "."
+ignores = "go."

--- a/back/docs/user_guide/guides/spectrogram_display.md
+++ b/back/docs/user_guide/guides/spectrogram_display.md
@@ -31,7 +31,7 @@ You can also navigate by scrolling.
 Just hover your mouse over the spectrogram or the bar at the bottom, then use your scroll wheel:
 
 - Scroll up and down: Move vertically through frequencies.
-    Most likely you won't see any changes as the default behaviour is to display the full frequency range.
+  Most likely you won't see any changes as the default behaviour is to display the full frequency range.
 - Ctrl + Scroll: Move horizontally through time.
 
 Zooming is just as easy:
@@ -88,6 +88,9 @@ Here's a breakdown of each setting:
 | Normalize Amplitude | Enable this to adjust the amplitude values to a 0-1 range. Useful for making quiet recordings easier to see.                                                                |
 | Min Amplitude       | Set the minimum amplitude (in decibels) to display. Values below this are set to the minimum and assigned the corresponding color. This can help reduce noise.              |
 | Max Amplitude       | Set the maximum amplitude (in decibels) to display. Values above this are set to the maximum and assigned the corresponding color. This can help highlight specific sounds. |
+| Duration            | Set the default time duration of the spectrogram window when it is first displayed.                                                                                         |
+| Min Frequency       | Set the default lower frequency limit (in Hz) for the initial spectrogram view. Users can freely navigate beyond this range after loading.                                  |
+| Max Frequency       | Set the default upper frequency limit (in Hz) for the initial spectrogram view. Users can freely navigate beyond this range after loading.                                  |
 
 ## Audio Player
 

--- a/front/src/app/components/annotation/AnnotationClip.tsx
+++ b/front/src/app/components/annotation/AnnotationClip.tsx
@@ -16,6 +16,7 @@ import Empty from "@/lib/components/ui/Empty";
 
 import useAnnotationState from "@/lib/hooks/annotation/useAnnotationState";
 import useAnnotationTagPallete from "@/lib/hooks/annotation/useAnnotationTagPalette";
+import useViewSettings from "@/lib/hooks/settings/useViewSettings";
 import useSpectrogramAudio from "@/lib/hooks/spectrogram/useSpectrogramAudio";
 import useSpectrogramState from "@/lib/hooks/spectrogram/useSpectrogramState";
 import useClipViewport from "@/lib/hooks/window/useClipViewport";
@@ -26,12 +27,14 @@ export default function ClipAnnotationSpectrogram({
   clipAnnotation,
   spectrogramSettings,
   audioSettings,
+  viewSettings,
   tagPalette,
   height,
 }: {
   clipAnnotation: ClipAnnotation;
   spectrogramSettings: ReturnType<typeof useSpectrogramSettings>;
   audioSettings: ReturnType<typeof useAudioSettings>;
+  viewSettings: ReturnType<typeof useViewSettings>;
   tagPalette: ReturnType<typeof useAnnotationTagPallete>;
   height?: number;
 }) {
@@ -47,6 +50,7 @@ export default function ClipAnnotationSpectrogram({
   const viewport = useClipViewport({
     clip: data.clip,
     spectrogramSettings: spectrogramSettings.settings,
+    viewSettings: viewSettings.settings,
   });
 
   const audio = useSpectrogramAudio({
@@ -81,6 +85,7 @@ export default function ClipAnnotationSpectrogram({
           samplerate={data.clip.recording.samplerate}
           audioSettings={audioSettings}
           spectrogramSettings={spectrogramSettings}
+          viewSettings={viewSettings}
         />
       }
       ViewportBar={<ViewportBar viewport={viewport} />}

--- a/front/src/app/components/annotation/AnnotationTasks.tsx
+++ b/front/src/app/components/annotation/AnnotationTasks.tsx
@@ -3,6 +3,7 @@ import { useHotkeys } from "react-hotkeys-hook";
 
 import useAudioSettings from "@/app/hooks/settings/useAudioSettings";
 import useSpectrogramSettings from "@/app/hooks/settings/useSpectrogramSettings";
+import useViewSettings from "@/app/hooks/settings/useViewSettings";
 
 import AnnotationProgress from "@/lib/components/annotation/AnnotationProgress";
 import AnnotationTaskBase from "@/lib/components/annotation/AnnotationTask";
@@ -33,6 +34,8 @@ export default function AnnotateTasks({
   const audioSettings = useAudioSettings();
 
   const spectrogramSettings = useSpectrogramSettings();
+
+  const viewSettings = useViewSettings();
 
   const tagPalette = useAnnotationTagPallete();
 
@@ -133,6 +136,7 @@ export default function AnnotateTasks({
           <ClipAnnotationSpectrogram
             clipAnnotation={tasks.annotations.data}
             audioSettings={audioSettings}
+            viewSettings={viewSettings}
             spectrogramSettings={spectrogramSettings}
             tagPalette={tagPalette}
           />

--- a/front/src/app/components/clip_annotations/ClipAnnotationSpectrogram.tsx
+++ b/front/src/app/components/clip_annotations/ClipAnnotationSpectrogram.tsx
@@ -15,6 +15,7 @@ import ClipAnnotationSpectrogramBase from "@/lib/components/clip_annotations/Cli
 import Empty from "@/lib/components/ui/Empty";
 
 import useAnnotationState from "@/lib/hooks/annotation/useAnnotationState";
+import useViewSettings from "@/lib/hooks/settings/useViewSettings";
 import useSpectrogramAudio from "@/lib/hooks/spectrogram/useSpectrogramAudio";
 import useSpectrogramState from "@/lib/hooks/spectrogram/useSpectrogramState";
 import useClipViewport from "@/lib/hooks/window/useClipViewport";
@@ -53,6 +54,8 @@ export default function ClipAnnotationSpectrogram({
 
   const spectrogramSettings = useSpectrogramSettings();
 
+  const viewSettings = useViewSettings();
+
   const spectrogramState = useSpectrogramState();
 
   const annotationState = useAnnotationState({ spectrogramState });
@@ -60,6 +63,7 @@ export default function ClipAnnotationSpectrogram({
   const viewport = useClipViewport({
     clip: data.clip,
     spectrogramSettings: spectrogramSettings.settings,
+    viewSettings: viewSettings.settings,
   });
 
   const audio = useSpectrogramAudio({
@@ -100,6 +104,7 @@ export default function ClipAnnotationSpectrogram({
             samplerate={data.clip.recording.samplerate}
             audioSettings={audioSettings}
             spectrogramSettings={spectrogramSettings}
+            viewSettings={viewSettings}
           />
         ) : undefined
       }

--- a/front/src/app/components/clip_evaluation/ClipEvaluationSpectrogram.tsx
+++ b/front/src/app/components/clip_evaluation/ClipEvaluationSpectrogram.tsx
@@ -10,6 +10,7 @@ import useSpectrogramSettings from "@/app/hooks/settings/useSpectrogramSettings"
 
 import RecordingSpectrogram from "@/lib/components/recordings/RecordingSpectrogram";
 
+import useViewSettings from "@/lib/hooks/settings/useViewSettings";
 import useSpectrogramAudio from "@/lib/hooks/spectrogram/useSpectrogramAudio";
 import useSpectrogramState from "@/lib/hooks/spectrogram/useSpectrogramState";
 import useClipViewport from "@/lib/hooks/window/useClipViewport";
@@ -33,9 +34,12 @@ export default function ClipEvaluationSpectrogram(
 
   const spectrogramSettings = useSpectrogramSettings();
 
+  const viewSettings = useViewSettings();
+
   const viewport = useClipViewport({
     clip,
     spectrogramSettings: spectrogramSettings.settings,
+    viewSettings: viewSettings.settings,
   });
 
   const audio = useSpectrogramAudio({
@@ -81,6 +85,7 @@ export default function ClipEvaluationSpectrogram(
             samplerate={recording.samplerate}
             audioSettings={audioSettings}
             spectrogramSettings={spectrogramSettings}
+            viewSettings={viewSettings}
           />
         ) : undefined
       }

--- a/front/src/app/components/recordings/RecordingSpectrogram.tsx
+++ b/front/src/app/components/recordings/RecordingSpectrogram.tsx
@@ -10,6 +10,7 @@ import useSpectrogramSettings from "@/app/hooks/settings/useSpectrogramSettings"
 
 import RecordingSpectrogramBase from "@/lib/components/recordings/RecordingSpectrogram";
 
+import useViewSettings from "@/lib/hooks/settings/useViewSettings";
 import useSpectrogramAudio from "@/lib/hooks/spectrogram/useSpectrogramAudio";
 import useSpectrogramState from "@/lib/hooks/spectrogram/useSpectrogramState";
 import useRecordingViewport from "@/lib/hooks/window/useRecordingViewport";
@@ -28,9 +29,12 @@ export default function RecordingSpectrogram({
 
   const spectrogramSettings = useSpectrogramSettings();
 
+  const viewSettings = useViewSettings();
+
   const viewport = useRecordingViewport({
     recording,
     spectrogramSettings: spectrogramSettings.settings,
+    viewSettings: viewSettings.settings,
   });
 
   const audio = useSpectrogramAudio({
@@ -76,6 +80,7 @@ export default function RecordingSpectrogram({
             samplerate={recording.samplerate}
             audioSettings={audioSettings}
             spectrogramSettings={spectrogramSettings}
+            viewSettings={viewSettings}
           />
         ) : undefined
       }

--- a/front/src/app/components/sound_event_annotations/SoundEventAnnotationSpectrogram.tsx
+++ b/front/src/app/components/sound_event_annotations/SoundEventAnnotationSpectrogram.tsx
@@ -14,6 +14,7 @@ import Error from "@/app/error";
 import ClipAnnotationSpectrogramBase from "@/lib/components/clip_annotations/ClipAnnotationSpectrogram";
 import Loading from "@/lib/components/ui/Loading";
 
+import useViewSettings from "@/lib/hooks/settings/useViewSettings";
 import useSpectrogramAudio from "@/lib/hooks/spectrogram/useSpectrogramAudio";
 import useSpectrogramState from "@/lib/hooks/spectrogram/useSpectrogramState";
 import useSoundEventViewport from "@/lib/hooks/window/useSoundEventViewport";
@@ -76,6 +77,8 @@ function Inner({
 
   const spectrogramSettings = useSpectrogramSettings();
 
+  const viewSettings = useViewSettings();
+
   const spectrogramState = useSpectrogramState();
 
   const viewport = useSoundEventViewport({
@@ -120,6 +123,7 @@ function Inner({
             samplerate={recording.samplerate}
             audioSettings={audioSettings}
             spectrogramSettings={spectrogramSettings}
+            viewSettings={viewSettings}
           />
         ) : undefined
       }

--- a/front/src/app/components/spectrograms/SettingsMenu.tsx
+++ b/front/src/app/components/spectrograms/SettingsMenu.tsx
@@ -3,6 +3,7 @@ import toast from "react-hot-toast";
 
 import useAudioSettings from "@/app/hooks/settings/useAudioSettings";
 import useSpectrogramSettings from "@/app/hooks/settings/useSpectrogramSettings";
+import useViewSettings from "@/app/hooks/settings/useViewSettings";
 
 import useStore from "@/app/store";
 
@@ -12,45 +13,58 @@ export default function SettingsMenu({
   samplerate,
   audioSettings,
   spectrogramSettings,
+  viewSettings,
 }: {
   samplerate: number;
   audioSettings: ReturnType<typeof useAudioSettings>;
   spectrogramSettings: ReturnType<typeof useSpectrogramSettings>;
+  viewSettings: ReturnType<typeof useViewSettings>;
 }) {
   const saveAudioSettings = useStore((state) => state.setAudioSettings);
   const saveSpectrogramSettings = useStore(
     (state) => state.setSpectrogramSettings,
   );
+  const saveViewSettings = useStore((state) => state.setViewSettings);
 
   const handleSave = useCallback(() => {
     saveAudioSettings(audioSettings.settings);
     saveSpectrogramSettings(spectrogramSettings.settings);
+    saveViewSettings(viewSettings.settings);
     toast.success("Settings saved");
   }, [
     audioSettings.settings,
     spectrogramSettings.settings,
+    viewSettings.settings,
     saveAudioSettings,
     saveSpectrogramSettings,
+    saveViewSettings,
   ]);
 
   const { dispatch: audioDispatch } = audioSettings;
   const { dispatch: spectrogramDispatch } = spectrogramSettings;
+  const { dispatch: viewDispatch } = viewSettings;
+
   const handleReset = useCallback(() => {
     spectrogramDispatch({ type: "reset" });
     audioDispatch({ type: "reset" });
+    viewDispatch({ type: "reset" });
     toast.success("Settings reset");
-  }, [audioDispatch, spectrogramDispatch]);
+  }, [audioDispatch, spectrogramDispatch, viewDispatch]);
 
   return (
     <SettingsMenuBase
       samplerate={samplerate}
       audioSettings={audioSettings.settings}
       spectrogramSettings={spectrogramSettings.settings}
+      viewSettings={viewSettings.settings}
       onAudioSettingsChange={(settings) =>
         audioDispatch({ type: "setAll", settings })
       }
       onSpectrogramSettingsChange={(settings) =>
         spectrogramDispatch({ type: "setAll", settings })
+      }
+      onViewSettingsChange={(settings) =>
+        viewDispatch({ type: "setAll", settings })
       }
       onSaveSettings={handleSave}
       onResetSettings={handleReset}

--- a/front/src/app/hooks/settings/useViewSettings.ts
+++ b/front/src/app/hooks/settings/useViewSettings.ts
@@ -1,0 +1,8 @@
+import useStore from "@/app/store";
+
+import useViewSettingsBase from "@/lib/hooks/settings/useViewSettings";
+
+export default function useViewSettings() {
+  const initialSettings = useStore((state) => state.viewSettings);
+  return useViewSettingsBase({ initialSettings });
+}

--- a/front/src/app/store/index.ts
+++ b/front/src/app/store/index.ts
@@ -8,12 +8,14 @@ import { type ClipboardSlice, createClipboardSlice } from "./clipboard";
 import { type ColorsSlice, createColorsSlice } from "./colors";
 import { type SessionSlice, createSessionSlice } from "./session";
 import { type SpectrogramSlice, createSpectrogramSlice } from "./spectrogram";
+import { type ViewSlice, createViewSlice } from "./view";
 
 type Store = SessionSlice &
   ClipboardSlice &
   ColorsSlice &
   SpectrogramSlice &
-  AudioSlice;
+  AudioSlice &
+  ViewSlice;
 
 const useStore = create<Store>()(
   persist(
@@ -23,6 +25,7 @@ const useStore = create<Store>()(
       ...createColorsSlice(...a),
       ...createSpectrogramSlice(...a),
       ...createAudioSlice(...a),
+      ...createViewSlice(...a),
     }),
     {
       name: "whombat-storage",

--- a/front/src/app/store/view.ts
+++ b/front/src/app/store/view.ts
@@ -1,0 +1,22 @@
+/** State for application wide spectrogram view settings. */
+import { StateCreator } from "zustand";
+
+import { DEFAULT_VIEW_SETTINGS } from "@/lib/constants";
+import type { ViewSettings } from "@/lib/types";
+
+export type ViewSlice = {
+  viewSettings: ViewSettings;
+  setViewSettings: (settings: ViewSettings) => void;
+};
+
+export const createViewSlice: StateCreator<ViewSlice> = (set) => ({
+  viewSettings: DEFAULT_VIEW_SETTINGS,
+  setViewSettings: (settings) => {
+    set((state) => {
+      return {
+        ...state,
+        viewSettings: settings,
+      };
+    });
+  },
+});

--- a/front/src/lib/components/annotation/AnnotationTask.stories.tsx
+++ b/front/src/lib/components/annotation/AnnotationTask.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import {
   DEFAULT_AUDIO_SETTINGS,
   DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
 } from "@/lib/constants";
 import type {
   AnnotationTask,
@@ -88,6 +89,7 @@ const meta: Meta<typeof AnnotationTaskComponent> = {
           <SettingsMenu
             audioSettings={DEFAULT_AUDIO_SETTINGS}
             spectrogramSettings={DEFAULT_SPECTROGRAM_SETTINGS}
+            viewSettings={DEFAULT_VIEW_SETTINGS}
             samplerate={samplerate}
           />
         }

--- a/front/src/lib/components/clip_annotations/ClipAnnotationSpectrogram.stories.tsx
+++ b/front/src/lib/components/clip_annotations/ClipAnnotationSpectrogram.stories.tsx
@@ -5,6 +5,7 @@ import ClipAnnotationSpectrogram from "@/lib/components/clip_annotations/ClipAnn
 import {
   DEFAULT_AUDIO_SETTINGS,
   DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
 } from "@/lib/constants";
 import type { SpectrogramWindow } from "@/lib/types";
 
@@ -64,6 +65,7 @@ export const Primary: Story = {
       <SettingsMenu
         audioSettings={DEFAULT_AUDIO_SETTINGS}
         spectrogramSettings={DEFAULT_SPECTROGRAM_SETTINGS}
+        viewSettings={DEFAULT_VIEW_SETTINGS}
         samplerate={samplerate}
       />
     ),

--- a/front/src/lib/components/recordings/RecordingDetail.stories.tsx
+++ b/front/src/lib/components/recordings/RecordingDetail.stories.tsx
@@ -10,6 +10,7 @@ import ViewportToolbar from "@/lib/components/spectrograms/ViewportToolbar";
 import {
   DEFAULT_AUDIO_SETTINGS,
   DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
 } from "@/lib/constants";
 import {
   type Note,
@@ -97,6 +98,7 @@ export const Primary: Story = {
           <SettingsMenu
             audioSettings={DEFAULT_AUDIO_SETTINGS}
             spectrogramSettings={DEFAULT_SPECTROGRAM_SETTINGS}
+            viewSettings={DEFAULT_VIEW_SETTINGS}
             samplerate={recording.samplerate}
           />
         }

--- a/front/src/lib/components/recordings/RecordingSpectrogram.stories.tsx
+++ b/front/src/lib/components/recordings/RecordingSpectrogram.stories.tsx
@@ -10,6 +10,7 @@ import ViewportToolbar from "@/lib/components/spectrograms/ViewportToolbar";
 import {
   DEFAULT_AUDIO_SETTINGS,
   DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
 } from "@/lib/constants";
 import type { SpectrogramWindow } from "@/lib/types";
 
@@ -59,6 +60,7 @@ export const Primary: Story = {
       <SettingsMenu
         audioSettings={DEFAULT_AUDIO_SETTINGS}
         spectrogramSettings={DEFAULT_SPECTROGRAM_SETTINGS}
+        viewSettings={DEFAULT_VIEW_SETTINGS}
         samplerate={samplerate}
       />
     ),

--- a/front/src/lib/components/settings/SettingsMenu.stories.tsx
+++ b/front/src/lib/components/settings/SettingsMenu.stories.tsx
@@ -34,6 +34,11 @@ export const Primary: Story = {
       channel: 0,
       speed: 1,
     },
+    viewSettings: {
+      duration: 1,
+      min_freq: 0,
+      max_freq: null,
+    },
     samplerate: 44100,
   },
 };

--- a/front/src/lib/components/settings/SettingsMenu.tsx
+++ b/front/src/lib/components/settings/SettingsMenu.tsx
@@ -3,27 +3,36 @@ import { useState } from "react";
 import { SettingsIcon } from "@/lib/components/icons";
 import AudioSettingsComponent from "@/lib/components/settings/AudioSettings";
 import SpectrogramSettingsComponent from "@/lib/components/settings/SpectrogramSettings";
+import ViewSettingsComponent from "@/lib/components/settings/ViewSettings";
 import Button from "@/lib/components/ui/Button";
 import { H3 } from "@/lib/components/ui/Headings";
 import SlideOver from "@/lib/components/ui/SlideOver";
 import Tooltip from "@/lib/components/ui/Tooltip";
 
-import type { AudioSettings, SpectrogramSettings } from "@/lib/types";
+import type {
+  AudioSettings,
+  SpectrogramSettings,
+  ViewSettings,
+} from "@/lib/types";
 
 export default function SettingsMenu({
   audioSettings,
   spectrogramSettings,
+  viewSettings,
   samplerate,
   onAudioSettingsChange,
   onSpectrogramSettingsChange,
+  onViewSettingsChange,
   onResetSettings,
   onSaveSettings,
 }: {
   audioSettings: AudioSettings;
   spectrogramSettings: SpectrogramSettings;
+  viewSettings: ViewSettings;
   samplerate: number;
   onAudioSettingsChange?: (settings: AudioSettings) => void;
   onSpectrogramSettingsChange?: (settings: SpectrogramSettings) => void;
+  onViewSettingsChange?: (settings: ViewSettings) => void;
   onResetSettings?: () => void;
   onSaveSettings?: () => void;
 }) {
@@ -67,6 +76,12 @@ export default function SettingsMenu({
             samplerate={samplerate}
             settings={spectrogramSettings}
             onChange={onSpectrogramSettingsChange}
+          />
+          <H3>View</H3>
+          <ViewSettingsComponent
+            samplerate={samplerate}
+            settings={viewSettings}
+            onChange={onViewSettingsChange}
           />
         </div>
       </SlideOver>

--- a/front/src/lib/components/settings/ViewSettings.stories.tsx
+++ b/front/src/lib/components/settings/ViewSettings.stories.tsx
@@ -1,0 +1,27 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
+
+import ViewSettings from "@/lib/components/settings/ViewSettings";
+
+const meta: Meta<typeof ViewSettings> = {
+  title: "Settings/ViewSettings",
+  component: ViewSettings,
+  args: {
+    samplerate: 44100,
+    onChange: fn(),
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof ViewSettings>;
+
+export const Primary: Story = {
+  args: {
+    settings: {
+      duration: 1,
+      min_freq: 0,
+      max_freq: null,
+    },
+  },
+};

--- a/front/src/lib/components/settings/ViewSettings.tsx
+++ b/front/src/lib/components/settings/ViewSettings.tsx
@@ -1,0 +1,127 @@
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useEffect } from "react";
+import { type Control, useController, useForm } from "react-hook-form";
+
+import { Group, RangeSlider, Slider } from "@/lib/components/inputs";
+import SettingsSection from "@/lib/components/settings/settings/SettingsSection";
+
+import { ViewSettingsSchema } from "@/lib/schemas";
+import type { ViewSettings } from "@/lib/types";
+import { debounce } from "@/lib/utils/debounce";
+
+import { InputHelp } from "../inputs/InputGroup";
+
+interface ViewSettingsProps {
+  settings: ViewSettings;
+  samplerate: number;
+  onChange?: (settings: ViewSettings) => void;
+  debounceTime?: number;
+}
+
+export default function ViewSettings({
+  settings,
+  samplerate,
+  onChange,
+  debounceTime = 300,
+}: ViewSettingsProps) {
+  const { handleSubmit, watch, control } = useForm({
+    resolver: zodResolver(ViewSettingsSchema),
+    mode: "onChange",
+    reValidateMode: "onChange",
+    values: settings,
+  });
+
+  useEffect(() => {
+    const debouncedCb = debounce(
+      handleSubmit((data) => {
+        onChange?.(data);
+      }),
+      debounceTime,
+    );
+    const subscription = watch(debouncedCb);
+    return () => subscription.unsubscribe();
+  }, [watch, handleSubmit, onChange, debounceTime]);
+
+  return (
+    <div className="flex flex-col gap-2">
+      <SettingsSection>
+        <div className="mb-2 text-sm text-stone-600 dark:text-stone-400">
+          Set the default spectrogram view. Changes won’t affect the current
+          spectrogram, only newly displayed ones.
+        </div>
+        <MinMaxFreqSettings control={control} samplerate={samplerate} />
+        <DurationSettings control={control} />
+      </SettingsSection>
+    </div>
+  );
+}
+
+function MinMaxFreqSettings({
+  control,
+  samplerate,
+}: {
+  control: Control<ViewSettings>;
+  samplerate: number;
+}) {
+  const minFreq = useController({
+    control,
+    name: "min_freq",
+  });
+
+  const maxFreq = useController({
+    control,
+    name: "max_freq",
+  });
+
+  return (
+    <Group
+      name="clampValues"
+      label="Frequency Range"
+      help="Set the default frequency range to display (in Hz). You can always zoom in or out to adjust the view later."
+      error={
+        minFreq.fieldState.error?.message || maxFreq.fieldState.error?.message
+      }
+    >
+      <RangeSlider
+        label="Frequency Range"
+        minValue={0}
+        maxValue={samplerate / 2}
+        step={2}
+        value={[
+          minFreq.field.value || 0,
+          maxFreq.field.value || samplerate / 2,
+        ]}
+        onChange={(value) => {
+          const [min, max] = value as number[];
+          minFreq.field.onChange(min);
+          maxFreq.field.onChange(max);
+        }}
+      />
+    </Group>
+  );
+}
+
+function DurationSettings({ control }: { control: Control<ViewSettings> }) {
+  const duration = useController({
+    control,
+    name: "duration",
+  });
+
+  return (
+    <Group
+      name="duration"
+      label="Duration"
+      help="Set the default duration to display (in seconds). You can always zoom in or out to adjust the view later."
+      error={duration.fieldState.error?.message}
+    >
+      <Slider
+        label="Duration"
+        minValue={0}
+        maxValue={10}
+        step={0.1}
+        value={duration.field.value}
+        onChange={(value) => duration.field.onChange(value)}
+      />
+    </Group>
+  );
+}

--- a/front/src/lib/constants.ts
+++ b/front/src/lib/constants.ts
@@ -3,6 +3,7 @@ import type {
   AudioSettings,
   SpectrogramParameters,
   SpectrogramSettings,
+  ViewSettings,
 } from "@/lib/types";
 
 /* Default values for the settings of the STFT computation
@@ -16,6 +17,11 @@ export const DEFAULT_WINDOW = "hann";
 export const DEFAULT_SCALE = "dB";
 export const DEFAULT_FILTER_ORDER = 5;
 export const DEFAULT_CMAP = "gray";
+
+/* Default settings for windows (viewing windows) */
+export const DEFAULT_VIEW_DURATION = 1;
+export const DEFAULT_VIEW_MIN_FREQ: number | null = 0;
+export const DEFAULT_VIEW_MAX_FREQ: number | null = null;
 
 /* Restrictions on the settings for the STFT computation
  * These are to prevent the user from setting parameters that
@@ -50,6 +56,12 @@ export const DEFAULT_SPECTROGRAM_SETTINGS: SpectrogramSettings = {
   normalize: true,
   pcen: false,
   cmap: DEFAULT_CMAP,
+};
+
+export const DEFAULT_VIEW_SETTINGS: ViewSettings = {
+  duration: 1,
+  min_freq: 0,
+  max_freq: null,
 };
 
 export const DEFAULT_SPECTROGRAM_PARAMETERS: SpectrogramParameters = {

--- a/front/src/lib/hooks/settings/useViewSettings.ts
+++ b/front/src/lib/hooks/settings/useViewSettings.ts
@@ -1,0 +1,96 @@
+import { useMemo } from "react";
+import { useImmerReducer } from "use-immer";
+
+import { DEFAULT_VIEW_SETTINGS } from "@/lib/constants";
+import type { ViewSettings } from "@/lib/types";
+
+/**
+ * Custom hook to manage spectrogram settings.
+ */
+export default function useViewSettings({
+  initialSettings = DEFAULT_VIEW_SETTINGS,
+}: {
+  /** The initial values for the spectrogram settings. */
+  initialSettings?: ViewSettings;
+} = {}): ViewSettingsInterface {
+  const reducer = useMemo(
+    () =>
+      createViewSettingsReducer({
+        initial: initialSettings,
+      }),
+    [initialSettings],
+  );
+  const [settings, dispatch] = useImmerReducer(reducer, initialSettings);
+  return {
+    settings,
+    dispatch,
+  };
+}
+
+/**
+ * Types of actions that can be dispatched to update the spectrogram settings.
+ */
+export type ViewSettingsAction =
+  | { type: "setAll"; settings: ViewSettings }
+  | { type: "setDuration"; duration: number }
+  | { type: "setMinFreq"; min_freq: number }
+  | { type: "setMaxFreq"; max_freq: number }
+  | { type: "reset" };
+
+/**
+ * Creates a reducer function to manage spectrogram settings.
+ */
+function createViewSettingsReducer({
+  initial,
+}: {
+  /** The initial spectrogram settings. */
+  initial: ViewSettings;
+}) {
+  return function spectrogramSettingsReducer(
+    draft: ViewSettings,
+    action: ViewSettingsAction,
+  ) {
+    switch (action.type) {
+      case "setAll": {
+        return action.settings;
+      }
+      case "setDuration": {
+        if (action.duration < 0) {
+          throw new Error("Window size must be non-negative");
+        }
+        draft.duration = action.duration;
+        break;
+      }
+      case "setMinFreq": {
+        if (action.min_freq < 0) {
+          throw new Error("Minimum frequency must be non-negative");
+        }
+        draft.min_freq = action.min_freq;
+        break;
+      }
+      case "setMaxFreq": {
+        if (action.max_freq < 0) {
+          throw new Error("Maximum frequency must be non-negative");
+        }
+        draft.max_freq = action.max_freq;
+        break;
+      }
+      case "reset": {
+        return initial;
+      }
+      default: {
+        // @ts-ignore
+        throw Error("Unknown action: " + action.type);
+      }
+    }
+  };
+}
+
+/**
+ * Interface for the spectrogram settings hook.
+ */
+export type ViewSettingsInterface = {
+  /** The current spectrogram settings. */
+  settings: ViewSettings;
+  dispatch: (action: ViewSettingsAction) => void;
+};

--- a/front/src/lib/hooks/spectrogram/useSpectrogram.ts
+++ b/front/src/lib/hooks/spectrogram/useSpectrogram.ts
@@ -13,6 +13,7 @@ import type {
   Recording,
   SpectrogramSettings,
   SpectrogramWindow,
+  ViewSettings,
 } from "@/lib/types";
 import { scaleTimeToViewport } from "@/lib/utils/geometry";
 import { getInitialViewingWindow } from "@/lib/utils/windows";
@@ -22,11 +23,13 @@ export default function useSpectrogram({
   bounds,
   audioSettings,
   spectrogramSettings,
+  viewSettings,
 }: {
   recording: Recording;
   bounds: SpectrogramWindow;
   audioSettings: AudioSettings;
   spectrogramSettings: SpectrogramSettings;
+  viewSettings?: ViewSettings;
 }) {
   const state = useSpectrogramState();
 
@@ -36,6 +39,7 @@ export default function useSpectrogram({
     samplerate: recording.samplerate,
     windowSize: spectrogramSettings.window_size,
     overlap: spectrogramSettings.overlap,
+    viewSettings,
   });
 
   const viewport = useViewport({

--- a/front/src/lib/hooks/window/useClipViewport.ts
+++ b/front/src/lib/hooks/window/useClipViewport.ts
@@ -2,16 +2,21 @@ import { useEffect, useMemo } from "react";
 
 import useViewport from "@/lib/hooks/window/useViewport";
 
-import { DEFAULT_SPECTROGRAM_SETTINGS } from "@/lib/constants";
-import type { Clip, SpectrogramSettings } from "@/lib/types";
+import {
+  DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
+} from "@/lib/constants";
+import type { Clip, SpectrogramSettings, ViewSettings } from "@/lib/types";
 import { getInitialViewingWindow } from "@/lib/utils/windows";
 
 export default function useClipViewport({
   clip,
   spectrogramSettings = DEFAULT_SPECTROGRAM_SETTINGS,
+  viewSettings = DEFAULT_VIEW_SETTINGS,
 }: {
   clip: Clip;
   spectrogramSettings?: SpectrogramSettings;
+  viewSettings?: ViewSettings;
 }) {
   const bounds = useMemo(
     () => ({
@@ -29,12 +34,14 @@ export default function useClipViewport({
         samplerate: clip.recording.samplerate,
         windowSize: spectrogramSettings.window_size,
         overlap: spectrogramSettings.overlap,
+        viewSettings,
       }),
     [
       bounds,
       clip.recording.samplerate,
       spectrogramSettings.window_size,
       spectrogramSettings.overlap,
+      viewSettings,
     ],
   );
 

--- a/front/src/lib/hooks/window/useRecordingViewport.ts
+++ b/front/src/lib/hooks/window/useRecordingViewport.ts
@@ -2,8 +2,11 @@ import { useMemo } from "react";
 
 import useViewport from "@/lib/hooks/window/useViewport";
 
-import { DEFAULT_SPECTROGRAM_SETTINGS } from "@/lib/constants";
-import type { Recording, SpectrogramSettings } from "@/lib/types";
+import {
+  DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
+} from "@/lib/constants";
+import type { Recording, SpectrogramSettings, ViewSettings } from "@/lib/types";
 import { getInitialViewingWindow } from "@/lib/utils/windows";
 
 export default function useRecordingViewport({
@@ -11,11 +14,13 @@ export default function useRecordingViewport({
   startTime = 0,
   endTime,
   spectrogramSettings = DEFAULT_SPECTROGRAM_SETTINGS,
+  viewSettings = DEFAULT_VIEW_SETTINGS,
 }: {
   recording: Recording;
   startTime?: number;
   endTime?: number;
   spectrogramSettings?: SpectrogramSettings;
+  viewSettings?: ViewSettings;
 }) {
   const bounds = useMemo(
     () => ({
@@ -31,6 +36,7 @@ export default function useRecordingViewport({
     samplerate: recording.samplerate,
     windowSize: spectrogramSettings.window_size,
     overlap: spectrogramSettings.overlap,
+    viewSettings,
   });
 
   const viewport = useViewport({

--- a/front/src/lib/schemas/settings.ts
+++ b/front/src/lib/schemas/settings.ts
@@ -5,6 +5,9 @@ import {
   DEFAULT_FILTER_ORDER,
   DEFAULT_OVERLAP,
   DEFAULT_SCALE,
+  DEFAULT_VIEW_DURATION,
+  DEFAULT_VIEW_MAX_FREQ,
+  DEFAULT_VIEW_MIN_FREQ,
   DEFAULT_WINDOW,
   DEFAULT_WINDOW_SIZE,
   MAX_SAMPLERATE,
@@ -159,3 +162,9 @@ export const SpectrogramParametersSchema = z
       path: ["min_dB"],
     },
   );
+
+export const ViewSettingsSchema = z.object({
+  duration: z.coerce.number().positive().default(DEFAULT_VIEW_DURATION),
+  min_freq: z.number().nonnegative().nullable().default(DEFAULT_VIEW_MIN_FREQ),
+  max_freq: z.number().nonnegative().nullable().default(DEFAULT_VIEW_MAX_FREQ),
+});

--- a/front/src/lib/types/settings.ts
+++ b/front/src/lib/types/settings.ts
@@ -11,3 +11,5 @@ export type AudioSettings = z.infer<typeof schemas.AudioSettingsSchema>;
 export type SpectrogramSettings = z.infer<
   typeof schemas.SpectrogramSettingsSchema
 >;
+
+export type ViewSettings = z.infer<typeof schemas.ViewSettingsSchema>;

--- a/front/src/lib/utils/windows.ts
+++ b/front/src/lib/utils/windows.ts
@@ -1,6 +1,7 @@
 import {
   DEFAULT_OVERLAP,
   DEFAULT_SPECTROGRAM_SETTINGS,
+  DEFAULT_VIEW_SETTINGS,
   DEFAULT_WINDOW_SIZE,
 } from "@/lib/constants";
 import type {
@@ -10,6 +11,7 @@ import type {
   Recording,
   SpectrogramSettings,
   SpectrogramWindow,
+  ViewSettings,
 } from "@/lib/types";
 
 import { computeGeometryBBox } from "./geometry";
@@ -29,22 +31,32 @@ export function getInitialViewingWindow({
   samplerate,
   windowSize,
   overlap,
+  viewSettings = DEFAULT_VIEW_SETTINGS,
 }: {
   startTime: number;
   endTime: number;
   samplerate: number;
   windowSize: number;
   overlap: number;
+  viewSettings?: ViewSettings;
 }): SpectrogramWindow {
-  const duration = getInitialDuration({
-    interval: { min: startTime, max: endTime },
-    samplerate,
-    windowSize: windowSize,
-    overlap,
-  });
+  let duration = viewSettings.duration;
+
+  if (duration == null) {
+    duration = getInitialDuration({
+      interval: { min: startTime, max: endTime },
+      samplerate,
+      windowSize: windowSize,
+      overlap,
+    });
+  }
+
+  let minFreq = viewSettings.min_freq ?? 0;
+  let maxFreq = viewSettings.max_freq ?? samplerate / 2;
+
   return {
     time: { min: startTime, max: startTime + duration },
-    freq: { min: 0, max: samplerate / 2 },
+    freq: { min: minFreq, max: maxFreq },
   };
 }
 


### PR DESCRIPTION
This PR introduces a new feature that allows users to configure the default viewing window when visualizing spectrograms.

Previously, the initial spectrogram view was determined automatically using a heuristic based on the recording’s sample rate and a target spectrogram width (in pixels), in order to keep initial computation lightweight. In addition, the frequency range was always set to the full spectrum, from 0 Hz to the Nyquist frequency.

While this approach works in general, it can be limiting for users who:

* Annotate sound events with longer temporal duration and need broader time context
* Focus primarily on a narrower frequency band rather than the full spectrum

**Changes**

* Adds a new **View Settings** section to the settings menu.
* Allows users to configure:

  * Default spectrogram duration (time window)
  * Default minimum frequency
  * Default maximum frequency
* These values are applied when a spectrogram is first displayed.
* Users can still freely navigate and adjust the spectrogram using existing zoom and navigation tools.

**Persistence**

The new view settings are stored in the browser’s local storage, consistent with existing audio and spectrogram settings. This provides persistence across sessions without requiring server-side configuration.

**Notes / Future Work**

It may be worth considering moving these settings into an **Annotation Project Settings** table in the future. For now, local storage provides a lightweight and sufficient solution.
