### PR TITLE
Fix typo in search task label

### DIFF
--- a/front/src/lib/components/annotation/AnnotationProgress.tsx
+++ b/front/src/lib/components/annotation/AnnotationProgress.tsx
@@ -76,7 +76,7 @@ function SearchTask({
       mode="text"
       variant="info"
       title="Search Task"
-      label="Seach"
+      label="Search"
       width="max-w-prose"
     >
       {() => (


### PR DESCRIPTION
There was a typo in the label used for the task search field in annotation mode.